### PR TITLE
iv_notify.3: Escape the minus sign in "-1"

### DIFF
--- a/modules/man3/iv_inotify.3
+++ b/modules/man3/iv_inotify.3
@@ -102,7 +102,7 @@ structure and a pointer to an inotify_event structure as described in
 .B iv_inotify_register
 and
 .B iv_inotify_watch_register
-return zero on success.  On error, -1 is returned, and errno is set
+return zero on success.  On error, \-1 is returned, and errno is set
 appropriately.
 .SH "ERRORS"
 iv_inotify will return errors returned by


### PR DESCRIPTION
Groff treats "-" as a hyphen by default, not as a minus sign. Since it is used as a minus sign, it's best to escape it.

Noticed by lintian, while packaging ivykis for Debian. Very minor, and quite possibly irrelevant too, as I can't imagine a situation where -1 would need to be hyphenated. But escaping makes lintian happy without an override, and does no harm either.
