### PR TITLE
iv_openssl: Add an OpenSSL linking exception.

### DIFF
--- a/contrib/iv_openssl/echo.c
+++ b/contrib/iv_openssl/echo.c
@@ -15,6 +15,18 @@
  * License version 2.1 along with this library; if not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
  * Boston, MA 02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give
+ * permission to link the code of portions of this program with the
+ * OpenSSL library under certain conditions as described in each
+ * individual source file, and distribute linked combinations
+ * including the two.
+ *
+ * You must obey the GNU Lesser General Public License in all respects
+ * for all of the code used other than OpenSSL. If you modify files
+ * with this exception, you may extend this exception to your version
+ * of the files, but you are not obligated to do so. If you do not
+ * wish to do so, delete this exception statement from your version.
  */
 
 #include <stdio.h>

--- a/contrib/iv_openssl/iv_openssl.c
+++ b/contrib/iv_openssl/iv_openssl.c
@@ -15,6 +15,18 @@
  * License version 2.1 along with this library; if not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
  * Boston, MA 02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give
+ * permission to link the code of portions of this program with the
+ * OpenSSL library under certain conditions as described in each
+ * individual source file, and distribute linked combinations
+ * including the two.
+ *
+ * You must obey the GNU Lesser General Public License in all respects
+ * for all of the code used other than OpenSSL. If you modify files
+ * with this exception, you may extend this exception to your version
+ * of the files, but you are not obligated to do so. If you do not
+ * wish to do so, delete this exception statement from your version.
  */
 
 #include <stdio.h>

--- a/contrib/iv_openssl/iv_openssl.h
+++ b/contrib/iv_openssl/iv_openssl.h
@@ -15,6 +15,18 @@
  * License version 2.1 along with this library; if not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
  * Boston, MA 02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give
+ * permission to link the code of portions of this program with the
+ * OpenSSL library under certain conditions as described in each
+ * individual source file, and distribute linked combinations
+ * including the two.
+ *
+ * You must obey the GNU Lesser General Public License in all respects
+ * for all of the code used other than OpenSSL. If you modify files
+ * with this exception, you may extend this exception to your version
+ * of the files, but you are not obligated to do so. If you do not
+ * wish to do so, delete this exception statement from your version.
  */
 
 #ifndef __IV_OPENSSL_H

--- a/contrib/iv_openssl/stress.c
+++ b/contrib/iv_openssl/stress.c
@@ -15,6 +15,18 @@
  * License version 2.1 along with this library; if not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
  * Boston, MA 02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give
+ * permission to link the code of portions of this program with the
+ * OpenSSL library under certain conditions as described in each
+ * individual source file, and distribute linked combinations
+ * including the two.
+ *
+ * You must obey the GNU Lesser General Public License in all respects
+ * for all of the code used other than OpenSSL. If you modify files
+ * with this exception, you may extend this exception to your version
+ * of the files, but you are not obligated to do so. If you do not
+ * wish to do so, delete this exception statement from your version.
  */
 
 #include <stdio.h>


### PR DESCRIPTION
Unfortunately, the OpenSSL license is incompatible with the (L)GPL, so
one needs a linking exception to be able to link with OpenSSL and not
violate either license.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
