### PR TITLE
Include all files required for building in the tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,4 +6,4 @@ SUBDIRS += man3
 endif
 endif
 
-EXTRA_DIST = DEDICATION
+EXTRA_DIST = DEDICATION libivykis.posix.ver libivykis.win32.ver

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -87,5 +87,8 @@ libivykis_la_LDFLAGS	= $(LINKFLAGS)
 include_HEADERS		= $(INC)
 
 noinst_HEADERS		= iv_private.h			\
+			  iv_event_private.h		\
+			  iv_fd_private.h		\
+			  iv_handle_private.h		\
 			  mutex.h			\
 			  spinlock.h


### PR DESCRIPTION
A couple of private, no-inst headers and the versioning linker scripts are needed to build ivykis, so include them all in the tarball.

Based on the stable-v0.36 branch, but should apply to master too, I believe.
