### PR TITLE
the `__iv_event_run_pending_events` exit condition cached

### DIFF
--- a/src/iv_event.c
+++ b/src/iv_event.c
@@ -43,22 +43,19 @@ static void __iv_event_run_pending_events(void *_st)
 	}
 
 	__iv_list_steal_elements(&st->events_pending, &events);
-	while (1) {
+	while (!iv_list_empty(&events)) {
 		struct iv_event *ie;
-		int empty_now;
 
 		ie = iv_container_of(events.next, struct iv_event, list);
 		iv_list_del_init(&ie->list);
-		empty_now = !!iv_list_empty(&events);
 
 		___mutex_unlock(&st->event_list_mutex);
 
 		ie->handler(ie->cookie);
-		if (empty_now)
-			break;
 
 		___mutex_lock(&st->event_list_mutex);
 	}
+	___mutex_unlock(&st->event_list_mutex);
 }
 
 void iv_event_init(struct iv_state *st)


### PR DESCRIPTION
The following commit: 0985782 tried to optimize out a lock by caching… the `iv_list_empty` operation.

It is possible to remove item from the list, while `ie->handler(ie->cookie)` runs, which could invalidates the value of the cached `empty_now` variable.
If no item left on the list, it should stop the loop, but it cached continue causing undefined behavior.

Fixes #13.
Fixes balabit/syslog-ng#

Signed-off-by: kokan <peter.kokai@balabit.com>