### PR TITLE
look for pthread_atfork() also in lib c_nonshared

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,6 +88,8 @@ esac
 # link in libpthread_nonshared.a if it is available.
 #
 AC_CHECK_LIB([pthread_nonshared], [pthread_atfork])
+# the lib is gone in glibc 2.28, things are now in c_nonshared
+AC_CHECK_LIB([c_nonshared], [pthread_atfork])
 
 # Checks for header files.
 AC_CHECK_HEADERS([process.h])

--- a/src/pthr.h
+++ b/src/pthr.h
@@ -42,7 +42,7 @@ static inline int pthreads_available(void)
  * symbol because that causes it to be undefined even if you link
  * libpthread_nonshared.a in explicitly.
  */
-#ifndef HAVE_LIBPTHREAD_NONSHARED
+#if !defined(HAVE_LIBPTHREAD_NONSHARED) && !defined(HAVE_LIBC_NONSHARED)
 #pragma weak pthread_atfork
 #endif
 


### PR DESCRIPTION
Newer versions of glibc do not have pthread_nonshared anymore, instead the symbol is in c_nonshared. This fixes a crash on start on those platforms (namely with syslog-ng).

The fix was inspired by https://github.com/buytenh/ivykis/issues/15#issuecomment-429097789.