### PR TITLE
fix build on m68k with uclibc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -110,6 +110,9 @@ AC_CACHE_CHECK(for linux/netfilter_ipv4.h, ac_cv_header_linux_netfilter_ipv4_h,
 # Check for pthread_spinlock_t.
 AC_CHECK_TYPES([pthread_spinlock_t], [], [], [[#include <pthread.h>]])
 
+# Check for pthread_spin_trylock
+AC_CHECK_FUNCS([pthread_spin_trylock])
+
 # Check which header file defines 'struct timespec'.
 for hdr in sys/time.h sys/timers.h time.h pthread.h
 do

--- a/src/spinlock.h
+++ b/src/spinlock.h
@@ -76,7 +76,11 @@ static inline void fallback_spin_unlock(fallback_spinlock_t *lock)
 
 static inline int pthread_spinlocks_available(void)
 {
+#ifdef HAVE_PTHREAD_SPIN_TRYLOCK
 	return !!(pthread_spin_trylock != NULL);
+#else
+	return 0;
+#endif
 }
 
 


### PR DESCRIPTION
uclibc on m68k defines pthread_spinlock_t but does not define
pthread_spin_trylock so check for this function before using it

Fixes:
 - http://autobuild.buildroot.org/results/0a6de11c030a4f39e402917809fc6d33fb463d1b

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>