### PR TITLE
test/server: fix unused return warning

### DIFF
--- a/test.mt/server.c
+++ b/test.mt/server.c
@@ -53,7 +53,11 @@ static void handler(void *_h)
 		int len;
 
 		len = snprintf(buf, 128, "this is port %d\n", h->port);
-		write(ret, buf, len);
+		int rc = write(ret, buf, len);
+		if (rc != len) {
+			perror("write");
+			exit(1);
+		}
 		close(ret);
 
 		if (!(++conns % 10000))


### PR DESCRIPTION
Compiling ivykis on ubuntu:bionic the following error occurs, which blocks compilation if warnings changed into error.

```bash
gcc -DHAVE_CONFIG_H -I.  -D_GNU_SOURCE -I./../src/include -I./../src/include   -g -O2 -Wall -pthread -MT server.o -MD -MP -MF .deps/server.Tpo -c -o server.o server.c
server.c: In function 'handler':
server.c:56:3: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
   write(ret, buf, len);
   ^~~~~~~~~~~~~~~~~~~~
```

Note:
This is required for syslog-ng in order to change the travis base image into ubuntu:bionic.