### PR TITLE
test.mt/configure.ac: quote usage of AC_SEARCH_LIBS

### DIFF
--- a/test.mt/configure.ac
+++ b/test.mt/configure.ac
@@ -142,9 +142,9 @@ ac_c_werror_flag=$ac_save_c_werror_flag
 # those (pthread_trace_notify_np is one of those symbols).
 #
 AC_SEARCH_LIBS([pthread_create], [pthread thread], [],
-	AC_SEARCH_LIBS([__pthread_create], [pthread], [],
-	AC_SEARCH_LIBS([pthread_trace_notify_np], [pthread], [],
-		AC_MSG_ERROR(pthreads support is required to build ivykis.))))
+	[AC_SEARCH_LIBS([__pthread_create], [pthread], [],
+	[AC_SEARCH_LIBS([pthread_trace_notify_np], [pthread], [],
+		[AC_MSG_ERROR(pthreads support is required to build ivykis.)])])])
 
 # Checks for libraries.
 AC_SEARCH_LIBS([socket], [socket])


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/871753

Hey there!

When backporting some upcoming fixes for Clang 16 into autoconf 2.71, we ran into some quoting issues in the `test.mt/configure.ac` autoconf script. Upstream added a commit that put a comma in one of the comments, which would lead to it, due to improper escaping, botching the libs= assignment it emits to include a bunch of C code. This patch appears to resolve all quoting issues.

Thanks!