### PR TITLE
iv.h.in: fix iv_now_location_valid() prototype

### DIFF
--- a/src/include/iv.h.in
+++ b/src/include/iv.h.in
@@ -54,7 +54,7 @@ unsigned long iv_get_thread_id(void);
 /*
  * Time handling.
  */
-const struct timespec *__iv_now_location_valid();
+const struct timespec *__iv_now_location_valid(void);
 
 #define iv_now			(*__iv_now_location_valid())
 #define iv_validate_now()


### PR DESCRIPTION
This fixes a compilation error:

error: function declaration isn’t a prototype [-Werror=strict-prototypes]