### PR TITLE
Explicitly allow linker version script to list not defined symbols.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -62,7 +62,8 @@ endif
 
 LINKFLAGS	= -version-info 5:6:5
 if HAVE_VERSIONING
-LINKFLAGS	+= -Wl,--version-script,$(top_srcdir)/libivykis.posix.ver
+LINKFLAGS	+= -Wl,--version-script,$(top_srcdir)/libivykis.posix.ver \
+		   -Wl,-undefined-version
 endif
 
 endif


### PR DESCRIPTION
LLVM switched to error presence of undefined symbols in the version map. The added key restores old behavior. The change is important to fix build on operating systems that don't build all of the APIs, for example FreeBSD doesn't have inotify. 