### PR TITLE
iv_fd_poll: epoll_pwait2() returns EPERM on CentOS7 with unprivileged…

### DIFF
--- a/src/iv_fd_epoll.c
+++ b/src/iv_fd_epoll.c
@@ -159,7 +159,7 @@ static int iv_fd_epoll_wait(struct iv_state *st, struct epoll_event *events,
 
 		ret = syscall(__NR_epoll_pwait2, epfd, events, maxevents,
 			      to_relative(st, &rel, abs), NULL);
-		if (ret == 0 || errno != ENOSYS)
+		if (ret == 0 || (errno != ENOSYS && errno != EPERM))
 			return ret;
 
 		epoll_pwait2_support = 0;


### PR DESCRIPTION
Under RHEL7 running an unprivileged container with a 3.10 based kernel, syslog-ng gets an abort, because the automatic fallback to epoll_pwait() does not work.

Because this is an unprivileged container and because on 3.10 epoll_pwait2() is an unknown system call, we get EPERM instead of ENOSYS.

See for example: https://github.com/axoflow/axosyslog/issues/85#issue-2281060511
