### PR TITLE
iv_fd_epoll: Only check errno if epoll_pwait2() returns -1

### DIFF
--- a/src/iv_fd_epoll.c
+++ b/src/iv_fd_epoll.c
@@ -168,7 +168,7 @@ static int iv_fd_epoll_wait(struct iv_state *st, struct epoll_event *events,
 		 * handle this by falling back to epoll_wait() just as if
 		 * -ENOSYS had been returned.
 		 */
-		if (ret == 0 || (errno != EPERM && errno != ENOSYS))
+		if (ret >= 0 || (errno != EPERM && errno != ENOSYS))
 			return ret;
 
 		epoll_pwait2_support = 0;


### PR DESCRIPTION
An `errno` can leak from inner execution paths. We should only care about the `errno` value if the syscall returns -1.

> On success, epoll_wait() returns the number of file descriptors
> ready for the requested I/O, or zero if no file descriptor became
> ready during the requested timeout milliseconds.  On failure,
> epoll_wait() returns -1 and errno is set to indicate the error.

--------------------------------------------------

The bug I observed was that ivykis did a fallback `epoll_wait()` call right after a successful `epoll_pwait2()` call (because it checked `errno`, even though `ret` was positive). As the first call returned the required number of events, the second call could not, so it hang for the timeout set, which was 10 minutes in my case.