### PR TITLE
build: let us silence pthread_self usage warning when -Werror is used

### DIFF
--- a/src/iv_tid_posix.c
+++ b/src/iv_tid_posix.c
@@ -53,7 +53,9 @@ unsigned long iv_get_thread_id(void)
 #elif defined(HAVE_THR_SELF) && defined(HAVE_THREAD_H)
 	thread_id = thr_self();
 #else
+#ifndef NO_PTHREAD_SELF_USAGE_WARNING
 #warning using pthread_self for iv_get_thread_id
+#endif
 	thread_id = pthr_self();
 #endif
 


### PR DESCRIPTION
If there's a #pragma option to silence this then the PR is meaningless, otherwise please let us silence this warning.

Signed-off-by: Hofi <hofione@gmail.com>