### PR TITLE
iv_uring: fix some uring issues

### DIFF
--- a/src/iv_fd.c
+++ b/src/iv_fd.c
@@ -320,7 +320,7 @@ static void iv_fd_register_prologue(struct iv_state *st, struct iv_fd_ *fd)
 	fd->ready_bands = 0;
 	fd->registered_bands = 0;
 #if defined(HAVE_SYS_DEVPOLL_H) || defined(HAVE_EPOLL_CREATE) ||	\
-    defined(HAVE_KQUEUE) || defined(HAVE_PORT_CREATE)
+    defined(HAVE_KQUEUE) || defined(HAVE_PORT_CREATE) || defined(HAVE_IO_URING_QUEUE_INIT)
 	INIT_IV_LIST_HEAD(&fd->list_notify);
 #endif
 

--- a/src/iv_fd_uring.c
+++ b/src/iv_fd_uring.c
@@ -217,7 +217,11 @@ static void iv_fd_uring_flush_one(struct iv_state *st, struct iv_fd_ *fd)
 
 	if (fd->registered_bands) {
 		sqe = iv_fd_uring_get_sqe(st);
-		io_uring_prep_poll_remove(sqe, fd);
+#ifdef LIBURING_HAVE_DATA64
+    io_uring_prep_poll_remove(sqe, (__u64)(uintptr_t)fd);
+#else
+    io_uring_prep_poll_remove(sqe, fd);
+#endif
 		io_uring_sqe_set_data(sqe, fd);
 		fd->u.sqes_in_flight++;
 	}

--- a/src/iv_fd_uring.c
+++ b/src/iv_fd_uring.c
@@ -92,7 +92,7 @@ static int iv_fd_uring_init(struct iv_state *st)
 			INIT_IV_LIST_HEAD(&st->u.uring.active);
 			st->u.uring.unsubmitted_sqes = 0;
 			st->u.uring.timer_expired = 0;
-
+			st->u.uring.ts = (struct __kernel_timespec){0};
 			return 0;
 		}
 
@@ -323,6 +323,11 @@ static int iv_fd_uring_poll(struct iv_state *st,
 	return st->u.uring.timer_expired;
 }
 
+static void iv_fd_uring_register_fd(struct iv_state *st, struct iv_fd_ *fd)
+{
+	fd->u.sqes_in_flight = 0;
+}
+
 static void iv_fd_uring_unregister_fd(struct iv_state *st, struct iv_fd_ *fd)
 {
 	if (!iv_list_empty(&fd->list_notify)) {
@@ -366,6 +371,7 @@ const struct iv_fd_poll_method iv_fd_poll_method_uring = {
 	.set_poll_timeout	= iv_fd_uring_set_poll_timeout,
 	.clear_poll_timeout	= iv_fd_uring_clear_poll_timeout,
 	.poll			= iv_fd_uring_poll,
+	.register_fd	= iv_fd_uring_register_fd,
 	.unregister_fd		= iv_fd_uring_unregister_fd,
 	.notify_fd		= iv_fd_uring_notify_fd,
 	.notify_fd_sync		= iv_fd_uring_notify_fd_sync,

--- a/src/iv_fd_uring.c
+++ b/src/iv_fd_uring.c
@@ -119,7 +119,7 @@ iv_fd_uring_handle_fd_cqe(struct iv_state *st, struct iv_list_head *active,
 
 		if (cqe->res & (POLLERR | POLLHUP))
 			iv_fd_make_ready(active, fd, MASKERR);
-	} else if (cqe->res != -ECANCELED) {
+	} else if (cqe->res != -ECANCELED && cqe->res != -ENOENT && cqe->res != 0) {
 		iv_fatal("iv_fd_uring_handle_fd_cqe: got error "
 			 "%d[%s] for fd %d", -cqe->res,
 			 strerror(-cqe->res), fd->fd);

--- a/src/iv_private_posix.h
+++ b/src/iv_private_posix.h
@@ -157,7 +157,7 @@ struct iv_fd_ {
 	uint8_t			registered_bands;
 
 #if defined(HAVE_SYS_DEVPOLL_H) || defined(HAVE_EPOLL_CREATE) ||	\
-    defined(HAVE_KQUEUE) || defined(HAVE_PORT_CREATE)
+    defined(HAVE_KQUEUE) || defined(HAVE_PORT_CREATE) || defined(HAVE_IO_URING_QUEUE_INIT)
 	/*
 	 * ->list_notify is used by poll methods that defer updating
 	 * kernel registrations to ->poll() time.
@@ -176,7 +176,9 @@ struct iv_fd_ {
 		struct iv_avl_node	avl_node;
 #endif
 		int			index;
+#ifdef HAVE_IO_URING_QUEUE_INIT
 		int			sqes_in_flight;
+#endif
 	} u;
 };
 


### PR DESCRIPTION
Found two issues in the current development version of the uring support:

- there were some missing constructs and initializations in the io_uring version of iv_fd_
- io_uring_cqe_get_data() can return ENOENT or 0 (no error) as well normally, that should not be treated as an error

Signed-off-by: Hofi <hofione@gmail.com>
