### PR TITLE
ivykis-internal: Add uring support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -106,6 +106,7 @@ AC_CHECK_LIB([c_nonshared], [pthread_atfork],
 AC_CHECK_LIB([pthread_nonshared], [pthread_atfork])
 
 # Checks for header files.
+AC_CHECK_HEADERS([liburing.h])
 AC_CHECK_HEADERS([process.h])
 AC_CHECK_HEADERS([sys/devpoll.h])
 AC_CHECK_HEADERS([sys/eventfd.h])
@@ -214,6 +215,7 @@ fi
 
 # Checks for libraries.
 AC_SEARCH_LIBS([inet_ntop], [nsl])
+AC_SEARCH_LIBS([io_uring_queue_init], [uring])
 AC_SEARCH_LIBS([socket], [socket])
 AC_SEARCH_LIBS([thr_self], [thread])
 
@@ -224,6 +226,7 @@ AC_CHECK_FUNCS([epoll_pwait2])
 AC_CHECK_FUNCS([eventfd])
 AC_CHECK_FUNCS([gettid])
 AC_CHECK_FUNCS([inotify_init])
+AC_CHECK_FUNCS([io_uring_queue_init])
 AC_CHECK_FUNCS([kqueue])
 AC_CHECK_FUNCS([lwp_gettid])
 AC_CHECK_FUNCS([pipe2])
@@ -303,6 +306,7 @@ AM_CONDITIONAL([HAVE_DEV_POLL], [test x$ac_cv_header_sys_devpoll_h = xyes])
 AM_CONDITIONAL([HAVE_EPOLL], [test x$ac_cv_func_epoll_create = xyes])
 AM_CONDITIONAL([HAVE_KQUEUE], [test x$ac_cv_func_kqueue = xyes])
 AM_CONDITIONAL([HAVE_PORT], [test x$ac_cv_func_port_create = xyes])
+AM_CONDITIONAL([HAVE_URING], [test x$ac_cv_func_io_uring_queue_init = xyes])
 
 # Other conditionals.
 AM_CONDITIONAL([CASE_INSENSITIVE_FS],

--- a/man3/ivykis.3
+++ b/man3/ivykis.3
@@ -10,6 +10,7 @@ ivykis \- library for asynchronous I/O readiness notification
 ivykis is a library for asynchronous I/O readiness notification.
 It is a thin, portable wrapper around OS-provided mechanisms such as
 .BR epoll_create (2),
+.BR io_uring_setup (2),
 .BR kqueue (2),
 .BR poll (2),
 .BR poll (7d)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -55,6 +55,10 @@ if HAVE_PORT
 SRC			+= iv_fd_port.c
 endif
 
+if HAVE_URING
+SRC			+= iv_fd_uring.c
+endif
+
 if HAVE_INOTIFY
 SRC			+= iv_inotify.c
 INC			+= include/iv_inotify.h

--- a/src/iv_fd.c
+++ b/src/iv_fd.c
@@ -372,7 +372,7 @@ static void iv_fd_register_prologue(struct iv_state *st, struct iv_fd_ *fd)
 	fd->ready_bands = 0;
 	fd->registered_bands = 0;
 #if defined(HAVE_SYS_DEVPOLL_H) || defined(HAVE_EPOLL_CREATE) ||	\
-    defined(HAVE_KQUEUE) || defined(HAVE_PORT_CREATE)
+    defined(HAVE_KQUEUE) || defined(HAVE_PORT_CREATE) || defined(HAVE_IO_URING_QUEUE_INIT)
 	INIT_IV_LIST_HEAD(&fd->list_notify);
 #endif
 

--- a/src/iv_fd.c
+++ b/src/iv_fd.c
@@ -124,6 +124,10 @@ static void select_poll_method(struct iv_state *st, char* select)
 #endif
 	else if (strcmp(select, iv_fd_poll_method_poll.name) == 0)
 		try_set_poll_method(st, &iv_fd_poll_method_poll);
+#ifdef HAVE_IO_URING_QUEUE_INIT
+	else if (strcmp(select, iv_fd_poll_method_uring.name) == 0)
+		try_set_poll_method(st, &iv_fd_poll_method_uring);
+#endif
 }
 
 static void try_select_poll_method(struct iv_state *st, char* exclude)
@@ -148,6 +152,10 @@ static void try_select_poll_method(struct iv_state *st, char* exclude)
 	consider_poll_method(st, exclude, &iv_fd_poll_method_ppoll);
 #endif
 	consider_poll_method(st, exclude, &iv_fd_poll_method_poll);
+#ifdef HAVE_IO_URING_QUEUE_INIT
+	/* Add uring as a last option for now still it is not stabilized perfectly */
+	consider_poll_method(st, exclude, &iv_fd_poll_method_uring);
+#endif
 }
 
 static void iv_fd_init_first_thread(struct iv_state *st)

--- a/src/iv_fd_uring.c
+++ b/src/iv_fd_uring.c
@@ -1,0 +1,373 @@
+/*
+ * ivykis, an event handling library
+ * Copyright (C) 2002, 2003, 2009, 2012, 2013, 2020 Lennert Buytenhek
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License version
+ * 2.1 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License version 2.1 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License version 2.1 along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <liburing.h>
+#include <poll.h>
+#include <string.h>
+#include "iv_private.h"
+
+static int uring_support = 1;
+
+static int iv_fd_uring_create(struct io_uring *ring)
+{
+	struct io_uring_probe *p;
+
+	if (io_uring_queue_init(256, ring, 0) < 0)
+		return 0;
+
+	p = io_uring_get_probe_ring(ring);
+	if (p == NULL) {
+		io_uring_queue_exit(ring);
+		return 0;
+	}
+
+	/*
+	 * Without Linux kernel commit 18bceab101ad ("io_uring: allow
+	 * POLL_ADD with double poll_wait() users"), IORING_OP_POLL_ADD
+	 * fails to work with (and returns -EINVAL for) certain
+	 * combinations of file descriptor types and poll event masks.
+	 * We would like to avoid using iv_fd_uring if the running kernel
+	 * doesn't have this fix, however, there is no (direct) way to
+	 * test for the presence of this fix in the running kernel.
+	 *
+	 * The fix was merged for Linux v5.8, so we could just make sure
+	 * that the version number of the running kernel is at least 5.8,
+	 * and refuse to initialize iv_fd_uring otherwise, but because
+	 * this fix may be backported to older (vendor) kernels, it may
+	 * be present in the running kernel even if the running kernel is
+	 * older than 5.8.
+	 *
+	 * Instead, we'll test for support for IORING_OP_TEE.  This
+	 * operation was added in kernel 5.8 as well, and if we're running
+	 * on a kernel that supports IORING_OP_TEE, we'll either be
+	 * running on >= 5.8, in which case we'll also have the POLL_ADD
+	 * fix, or we'll be running on a kernel that is older than 5.8
+	 * and that has had the IORING_OP_TEE feature backported, in
+	 * which case we are going to hope that the vendor will have been
+	 * nice enough to backport the POLL_ADD fix at the same time.
+	 *
+	 * Instead of referencing IORING_OP_TEE by name, we use its
+	 * numerical value (33).  We might be compiling against an older
+	 * io_uring.h kernel header which doesn't have IORING_OP_TEE
+	 * defined, and since uring operation codes are defined via an
+	 * enum, and not with #define statements, we cannot check for its
+	 * presence by using #ifdef -- however, unlike system call numbers,
+	 * uring operation codes are the same on every architecture that
+	 * Linux runs on, which is why we can just hardcode the value.
+	 */
+	if (!io_uring_opcode_supported(p, 33)) {
+		free(p);
+		io_uring_queue_exit(ring);
+		return 0;
+	}
+
+	free(p);
+
+	return 1;
+}
+
+static int iv_fd_uring_init(struct iv_state *st)
+{
+	if (uring_support) {
+		if (iv_fd_uring_create(&st->u.uring.ring)) {
+			INIT_IV_LIST_HEAD(&st->u.uring.notify);
+			INIT_IV_LIST_HEAD(&st->u.uring.active);
+			st->u.uring.unsubmitted_sqes = 0;
+			st->u.uring.timer_expired = 0;
+
+			return 0;
+		}
+
+		uring_support = 0;
+	}
+
+	return -1;
+}
+
+static void
+iv_fd_uring_handle_fd_cqe(struct iv_state *st, struct iv_list_head *active,
+			  struct io_uring_cqe *cqe)
+{
+	struct iv_fd_ *fd;
+
+	fd = io_uring_cqe_get_data(cqe);
+
+	if (cqe->res > 0) {
+		if (cqe->res & (POLLIN | POLLERR | POLLHUP))
+			iv_fd_make_ready(active, fd, MASKIN);
+
+		if (cqe->res & (POLLOUT | POLLERR | POLLHUP))
+			iv_fd_make_ready(active, fd, MASKOUT);
+
+		if (cqe->res & (POLLERR | POLLHUP))
+			iv_fd_make_ready(active, fd, MASKERR);
+	} else if (cqe->res != -ECANCELED) {
+		iv_fatal("iv_fd_uring_handle_fd_cqe: got error "
+			 "%d[%s] for fd %d", -cqe->res,
+			 strerror(-cqe->res), fd->fd);
+	}
+
+	fd->u.sqes_in_flight--;
+	if (!fd->u.sqes_in_flight) {
+		fd->registered_bands = 0;
+
+		iv_list_del_init(&fd->list_notify);
+		if (fd->wanted_bands) {
+			iv_list_add_tail(&fd->list_notify,
+					 &st->u.uring.notify);
+		}
+	}
+}
+
+static void
+iv_fd_uring_drain_cqes(struct iv_state *st, struct iv_list_head *active)
+{
+	int count;
+	uint32_t head;
+	struct io_uring_cqe *cqe;
+
+	count = 0;
+	io_uring_for_each_cqe (&st->u.uring.ring, head, cqe) {
+		count++;
+
+		if (cqe->user_data == (unsigned long)&st->time) {
+			if (cqe->res == -ETIME)
+				st->u.uring.timer_expired = 1;
+		} else {
+			iv_fd_uring_handle_fd_cqe(st, active, cqe);
+		}
+	}
+
+	io_uring_cq_advance(&st->u.uring.ring, count);
+}
+
+static void iv_fd_uring_submit_sqes(struct iv_state *st)
+{
+	if (st->u.uring.unsubmitted_sqes) {
+		int ret;
+
+		ret = io_uring_submit(&st->u.uring.ring);
+		if (ret < 0) {
+			if (errno != EINTR && errno != EBUSY) {
+				iv_fatal("iv_fd_uring_submit_sqes: got error "
+					 "%d[%s]", errno, strerror(errno));
+			}
+			return;
+		}
+
+		st->u.uring.unsubmitted_sqes -= ret;
+	}
+}
+
+static struct io_uring_sqe *iv_fd_uring_get_sqe(struct iv_state *st)
+{
+	struct io_uring_sqe *sqe;
+
+	sqe = io_uring_get_sqe(&st->u.uring.ring);
+	while (sqe == NULL) {
+		iv_fd_uring_drain_cqes(st, &st->u.uring.active);
+		iv_fd_uring_submit_sqes(st);
+		sqe = io_uring_get_sqe(&st->u.uring.ring);
+	}
+
+	st->u.uring.unsubmitted_sqes++;
+
+	return sqe;
+}
+
+static int bits_to_poll_mask(int bits)
+{
+	int mask;
+
+	mask = 0;
+	if (bits & MASKIN)
+		mask |= POLLIN;
+	if (bits & MASKOUT)
+		mask |= POLLOUT;
+
+	return mask;
+}
+
+static void iv_fd_uring_flush_one(struct iv_state *st, struct iv_fd_ *fd)
+{
+	struct io_uring_sqe *sqe;
+
+	iv_list_del_init(&fd->list_notify);
+
+	if (fd->registered_bands == fd->wanted_bands)
+		return;
+
+	if (fd->registered_bands) {
+		sqe = iv_fd_uring_get_sqe(st);
+		io_uring_prep_poll_remove(sqe, fd);
+		io_uring_sqe_set_data(sqe, fd);
+		fd->u.sqes_in_flight++;
+	}
+
+	if (fd->wanted_bands) {
+		sqe = iv_fd_uring_get_sqe(st);
+		io_uring_prep_poll_add(sqe, fd->fd,
+				       bits_to_poll_mask(fd->wanted_bands));
+		io_uring_sqe_set_data(sqe, fd);
+		fd->u.sqes_in_flight++;
+	}
+
+	fd->registered_bands = fd->wanted_bands;
+}
+
+static void iv_fd_uring_flush_pending(struct iv_state *st)
+{
+	while (!iv_list_empty(&st->u.uring.notify)) {
+		struct iv_fd_ *fd;
+
+		fd = iv_list_entry(st->u.uring.notify.next,
+				   struct iv_fd_, list_notify);
+
+		iv_fd_uring_flush_one(st, fd);
+	}
+}
+
+static void iv_fd_uring_set_timeout(struct iv_state *st,
+				    const struct timespec *abs,
+				    unsigned int count)
+{
+	struct io_uring_sqe *sqe;
+
+	memset(&st->u.uring.ts, 0, sizeof(st->u.uring.ts));
+	st->u.uring.ts.tv_sec = abs->tv_sec;
+	st->u.uring.ts.tv_nsec = abs->tv_nsec;
+
+	sqe = iv_fd_uring_get_sqe(st);
+	io_uring_prep_timeout(sqe, &st->u.uring.ts, count, IORING_TIMEOUT_ABS);
+	io_uring_sqe_set_data(sqe, &st->time);
+
+	st->u.uring.timer_expired = 0;
+}
+
+static int iv_fd_uring_set_poll_timeout(struct iv_state *st,
+					const struct timespec *abs)
+{
+	iv_fd_uring_set_timeout(st, abs, 0);
+
+	return 1;
+}
+
+static void iv_fd_uring_clear_poll_timeout(struct iv_state *st)
+{
+	struct io_uring_sqe *sqe;
+
+	sqe = iv_fd_uring_get_sqe(st);
+	io_uring_prep_timeout_remove(sqe, (unsigned long)&st->time, 0);
+	io_uring_sqe_set_data(sqe, &st->time);
+}
+
+static int iv_fd_uring_poll(struct iv_state *st,
+			    struct iv_list_head *active,
+			    const struct timespec *abs)
+{
+	int ret;
+
+	iv_fd_uring_drain_cqes(st, &st->u.uring.active);
+
+	if (!iv_list_empty(&st->u.uring.active)) {
+		__iv_list_steal_elements(&st->u.uring.active, active);
+		return 1;
+	}
+
+	iv_fd_uring_flush_pending(st);
+
+	if (abs != NULL) {
+		if (!st->time_valid) {
+			st->time_valid = 1;
+			iv_time_get(&st->time);
+		}
+
+		if (!timespec_gt(abs, &st->time)) {
+			iv_fd_uring_submit_sqes(st);
+			iv_fd_uring_drain_cqes(st, active);
+			return 1;
+		}
+
+		iv_fd_uring_set_timeout(st, abs, 1);
+	}
+
+	ret = io_uring_submit_and_wait(&st->u.uring.ring, 1);
+
+	__iv_invalidate_now(st);
+
+	if (ret < 0 && errno != EINTR && errno != EBUSY) {
+		iv_fatal("iv_fd_uring_poll: got error %d[%s]", errno,
+			 strerror(errno));
+	}
+
+	iv_fd_uring_drain_cqes(st, active);
+
+	return st->u.uring.timer_expired;
+}
+
+static void iv_fd_uring_unregister_fd(struct iv_state *st, struct iv_fd_ *fd)
+{
+	if (!iv_list_empty(&fd->list_notify)) {
+		iv_fd_uring_flush_one(st, fd);
+
+		do {
+			iv_fd_uring_submit_sqes(st);
+			iv_fd_uring_drain_cqes(st, &st->u.uring.active);
+		} while (fd->u.sqes_in_flight && st->u.uring.unsubmitted_sqes);
+
+		if (fd->u.sqes_in_flight) {
+			iv_fatal("iv_fd_uring_unregister_fd: fd %d appears "
+				 "stuck (%d)\n", fd->fd, fd->u.sqes_in_flight);
+		}
+	}
+}
+
+static void iv_fd_uring_notify_fd(struct iv_state *st, struct iv_fd_ *fd)
+{
+	iv_list_del_init(&fd->list_notify);
+	if (fd->registered_bands != fd->wanted_bands)
+		iv_list_add_tail(&fd->list_notify, &st->u.uring.notify);
+}
+
+static int iv_fd_uring_notify_fd_sync(struct iv_state *st, struct iv_fd_ *fd)
+{
+	iv_fd_uring_flush_one(st, fd);
+	iv_fd_uring_submit_sqes(st);
+
+	return 0;
+}
+
+static void iv_fd_uring_deinit(struct iv_state *st)
+{
+	io_uring_queue_exit(&st->u.uring.ring);
+}
+
+const struct iv_fd_poll_method iv_fd_poll_method_uring = {
+	.name			= "uring",
+	.init			= iv_fd_uring_init,
+	.set_poll_timeout	= iv_fd_uring_set_poll_timeout,
+	.clear_poll_timeout	= iv_fd_uring_clear_poll_timeout,
+	.poll			= iv_fd_uring_poll,
+	.unregister_fd		= iv_fd_uring_unregister_fd,
+	.notify_fd		= iv_fd_uring_notify_fd,
+	.notify_fd_sync		= iv_fd_uring_notify_fd_sync,
+	.deinit			= iv_fd_uring_deinit,
+};

--- a/src/iv_fd_uring.c
+++ b/src/iv_fd_uring.c
@@ -92,7 +92,7 @@ static int iv_fd_uring_init(struct iv_state *st)
 			INIT_IV_LIST_HEAD(&st->u.uring.active);
 			st->u.uring.unsubmitted_sqes = 0;
 			st->u.uring.timer_expired = 0;
-
+			st->u.uring.ts = (struct __kernel_timespec){0};
 			return 0;
 		}
 
@@ -323,6 +323,11 @@ static int iv_fd_uring_poll(struct iv_state *st,
 	return st->u.uring.timer_expired;
 }
 
+static void iv_fd_uring_register_fd(struct iv_state *st, struct iv_fd_ *fd)
+{
+	fd->u.sqes_in_flight = 0;
+}
+
 static void iv_fd_uring_unregister_fd(struct iv_state *st, struct iv_fd_ *fd)
 {
 	if (!iv_list_empty(&fd->list_notify)) {
@@ -366,6 +371,7 @@ const struct iv_fd_poll_method iv_fd_poll_method_uring = {
 	.set_poll_timeout	= iv_fd_uring_set_poll_timeout,
 	.clear_poll_timeout	= iv_fd_uring_clear_poll_timeout,
 	.poll			= iv_fd_uring_poll,
+	.register_fd	= iv_fd_uring_register_fd,
 	.unregister_fd		= iv_fd_uring_unregister_fd,
 	.notify_fd		= iv_fd_uring_notify_fd,
 	.notify_fd_sync		= iv_fd_uring_notify_fd_sync,

--- a/src/iv_fd_uring.c
+++ b/src/iv_fd_uring.c
@@ -119,7 +119,7 @@ iv_fd_uring_handle_fd_cqe(struct iv_state *st, struct iv_list_head *active,
 
 		if (cqe->res & (POLLERR | POLLHUP))
 			iv_fd_make_ready(active, fd, MASKERR);
-	} else if (cqe->res != -ECANCELED) {
+	} else if (cqe->res != -ECANCELED && cqe->res != -ENOENT && cqe->res != 0) {
 		iv_fatal("iv_fd_uring_handle_fd_cqe: got error "
 			 "%d[%s] for fd %d", -cqe->res,
 			 strerror(-cqe->res), fd->fd);

--- a/src/iv_private_posix.h
+++ b/src/iv_private_posix.h
@@ -157,7 +157,7 @@ struct iv_fd_ {
 	uint8_t			registered_bands;
 
 #if defined(HAVE_SYS_DEVPOLL_H) || defined(HAVE_EPOLL_CREATE) ||	\
-    defined(HAVE_KQUEUE) || defined(HAVE_PORT_CREATE)
+    defined(HAVE_KQUEUE) || defined(HAVE_PORT_CREATE) || defined(HAVE_IO_URING_QUEUE_INIT)
 	/*
 	 * ->list_notify is used by poll methods that defer updating
 	 * kernel registrations to ->poll() time.
@@ -176,7 +176,9 @@ struct iv_fd_ {
 		struct iv_avl_node	avl_node;
 #endif
 		int			index;
+#ifdef HAVE_IO_URING_QUEUE_INIT
 		int			sqes_in_flight;
+#endif
 	} u;
 };
 

--- a/src/iv_tid_posix.c
+++ b/src/iv_tid_posix.c
@@ -53,8 +53,10 @@ unsigned long iv_get_thread_id(void)
 #elif defined(HAVE_THR_SELF) && defined(HAVE_THREAD_H)
 	thread_id = thr_self();
 #else
+#ifndef NO_PTHREAD_SELF_USAGE_WARNING
 #warning using pthread_self for iv_get_thread_id
 	thread_id = pthr_self();
+#endif
 #endif
 
 	return thread_id;


### PR DESCRIPTION
Experimental integration of the uring-based poll method support.

Currently this must be activated directly by the user either using IV_EXCLUDE_POLL_METHOD or IV_SELECT_POLL_METHOD.

Partially solves https://github.com/syslog-ng/syslog-ng/issues/5019, partially because this one is not a huge performance enhancement on regular files as it is still a poll that always signals file readability, we still need a much better (kqueue-like) solution e.g. inotify.

Depends on https://github.com/syslog-ng/syslog-ng/pull/5308