### PR TITLE
configure: warning fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ(2.59)
 AC_INIT([ivykis], [0.43.2], [libivykis-discuss@lists.sourceforge.net])
 AC_CONFIG_SRCDIR([src/iv_avl.c])
 AC_CONFIG_SUBDIRS([test.mt])
-AC_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([foreign])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES])
 
@@ -22,9 +22,8 @@ aix7.*)
 esac
 
 # Checks for programs.
-LT_INIT
+LT_INIT([win32-dll])
 AC_PROG_CC
-AC_PROG_LIBTOOL
 
 # Build with -Wall.
 CFLAGS="$CFLAGS -Wall"
@@ -285,11 +284,6 @@ AC_CACHE_CHECK(whether $LD supports symbol version scripts,
 		[ac_cv_prog_ld_version_script=yes], [])
 	])
 LDFLAGS=$ac_save_LDFLAGS
-
-else
-
-# Build a libivykis DLL.
-AC_LIBTOOL_WIN32_DLL
 
 fi
 

--- a/test.mt/configure.ac
+++ b/test.mt/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ(2.59)
 AC_INIT([ivykis-test-mt], [0.1], [libivykis-discuss@lists.sourceforge.net])
 AC_CONFIG_SRCDIR([iv_event_bench.c])
-AC_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([foreign])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES])
 


### PR DESCRIPTION
- Changed AC_CONFIG_HEADER to AC_CONFIG_HEADERS
- Removed obsolete AC_PROG_LIBTOOL (duplicate of LT_INIT)
- Removed obsolete AC_LIBTOOL_WIN32_DLL and added win32-dll option to LT_INIT

Signed-off-by: Hofi hofione@gmail.com