### PR TITLE
building: let us silence some warnings to aid building when -Werror is used

### DIFF
--- a/src/iv_tid_posix.c
+++ b/src/iv_tid_posix.c
@@ -53,8 +53,10 @@ unsigned long iv_get_thread_id(void)
 #elif defined(HAVE_THR_SELF) && defined(HAVE_THREAD_H)
 	thread_id = thr_self();
 #else
+#ifndef NO_PTHREAD_SELF_USAGE_WARNING
 #warning using pthread_self for iv_get_thread_id
 	thread_id = pthr_self();
+#endif
 #endif
 
 	return thread_id;

--- a/test.mt/server.c
+++ b/test.mt/server.c
@@ -53,7 +53,8 @@ static void handler(void *_h)
 		int len;
 
 		len = snprintf(buf, 128, "this is port %d\n", h->port);
-		write(ret, buf, len);
+		ssize_t written = write(ret, buf, len);
+		(void)written; // silence ignoring return value  (and this way, unused variable) warning
 		close(ret);
 
 		if (!(++conns % 10000))


### PR DESCRIPTION
- pthread_self usage warning
- ignoring return value of ‘write’ warning

It is a re-request of https://github.com/buytenh/ivykis/pull/38, which is auto-closed after merge, and its original source is deleted, so it cannot be reopened.